### PR TITLE
Read imu in thread to increase data rate to 100hz. Must set 100khz I2C baud in /boot/firmware/config.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,12 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(tf2 REQUIRED)
 
-file(GLOB sources "src/*.cpp" "src/rt/*.c"  "src/rt/*.cpp")
-
 # add compile directive for shared library
 add_library(control_board_hardware_interface SHARED
-  ${sources}
+  src/control_board_hardware_interface.cpp
+  src/rt/rt_spi.cpp
+  src/rt/rt_bno055.cpp
+  src/imu_manager.cpp
 )
 
 # add include directory

--- a/include/control_board_hardware_interface/control_board_hardware_interface.hpp
+++ b/include/control_board_hardware_interface/control_board_hardware_interface.hpp
@@ -1,23 +1,27 @@
 #pragma once
 
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
+
 #include <memory>
+#include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "imu_manager.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
-#include "rt/rt_bno055.h"
 #include "rt/rt_spi.h"
-
-#define IMU_I2C_DEVICE_NUMBER 1
 
 // Overload the << operator for vector and array
 template <typename T>
@@ -80,7 +84,7 @@ class ControlBoardHardwareInterface : public hardware_interface::SystemInterface
   void do_homing();
   bool hw_states_contains_nan();
 
-  std::unique_ptr<BNO055> imu_ = nullptr;
+  IMUManager imu_manager_;
 
   // TODO: Refactor the horrible c-style spi code
   spi_command_t *spi_command_;

--- a/include/control_board_hardware_interface/imu_manager.hpp
+++ b/include/control_board_hardware_interface/imu_manager.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
+
+#include <atomic>
+#include <eigen3/Eigen/Dense>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <thread>
+#include <utility>
+
+#include "rt/rt_bno055.h"
+
+#define IMU_I2C_DEVICE_NUMBER 1
+
+class IMUManager {
+ public:
+  // whether IMU is enabled on robot
+  bool enabled;
+
+  // Latest copy of imu data (thread safe)
+  BNO055::Output imu_data;
+  uint32_t imu_sampling_time_us;
+
+  // IMU offset
+  tf2::Matrix3x3 offset_rotation_matrix;
+  tf2::Quaternion offset_quaternion;
+
+  // Set rotation matrix based on roll, pitch, yaw
+  void set_imu_offset(double roll, double pitch, double yaw);
+
+  // Begin threads and start reading IMU data
+  void begin(uint32_t micros_between_reports);
+
+  // Stop reading threads
+  void stop();
+
+ private:
+  bool contains_nan(const Eigen::Quaternionf &q);
+
+  std::optional<std::pair<BNO055::Output, uint32_t>> sample_imu_multiple_attempts(int max_samples,
+                                                                                  int delay_ms);
+
+  void poll_imu();
+
+  void imu_read_thread_fn();
+
+  const char *RED_ANSI = "\033[1;31m";
+  const char *YELLOW_ANSI = "\033[1;33m";
+  const char *RESET_ANSI = "\033[0m";
+
+  // mutex for imu
+  std::mutex imu_mutex_;
+  // ptr to thread for imu reading
+  std::unique_ptr<std::thread> imu_read_thread_ = nullptr;
+  // signal to stop read thread
+  std::atomic<bool> stop_imu_read_thread_;
+
+  // Imu reader
+  std::unique_ptr<BNO055> imu_ = nullptr;
+};

--- a/include/rt/rt_bno055.h
+++ b/include/rt/rt_bno055.h
@@ -68,7 +68,7 @@ class BNO055 {
   int16_t gyro_Q1 = 9;
   int16_t magnetometer_Q1 = 4;
 
-  BNO055(int i2c_device_number);
+  BNO055(int i2c_device_number, uint32_t micros_between_reports);
 
   ~BNO055();
 
@@ -82,7 +82,7 @@ class BNO055 {
     Eigen::Vector3f gyro;
   };
 
-  void sample(Output &result);
+  Output sample();
   void read_vector(int addr, float scale, int num_elt, float *out);
 
  private:
@@ -116,7 +116,7 @@ class BNO055 {
   bool receivePacket(void);
   bool getData(uint16_t bytesRemaining);
   bool waitForI2C(void);
-  void setFeatureCommand(uint8_t reportID, uint16_t timeBetweenReports, uint32_t specificConfig);
+  void setFeatureCommand(uint8_t reportID, uint32_t microsBetweenReports, uint32_t specificConfig);
   void enableRotationVector(uint16_t timeBetweenReports);
   void enableGyro(uint16_t timeBetweenReports);
   void enableLinearAccelerometer(uint16_t timeBetweenReports);

--- a/src/imu_manager.cpp
+++ b/src/imu_manager.cpp
@@ -1,0 +1,70 @@
+#include "control_board_hardware_interface/imu_manager.hpp"
+
+// set rotation matrix based on roll, pitch, yaw
+void IMUManager::set_imu_offset(double roll, double pitch, double yaw) {
+  offset_quaternion.setRPY(roll, pitch, yaw);
+  offset_rotation_matrix = tf2::Matrix3x3(offset_quaternion);
+}
+
+bool IMUManager::contains_nan(const Eigen::Quaternionf &q) {
+  return std::isnan(q.x()) || std::isnan(q.y()) || std::isnan(q.z()) || std::isnan(q.w());
+}
+
+std::optional<std::pair<BNO055::Output, uint32_t>> IMUManager::sample_imu_multiple_attempts(
+    int max_samples, int delay_ms) {
+  /*
+   * Sample the IMU up to max_samples times until a good sample is received.
+   * A good sample is defined as a quaternion that is not near zero and not NaN.
+   */
+
+  // Record start time
+  auto start = std::chrono::high_resolution_clock::now();
+
+  for (int i = 0; i < max_samples; i++) {
+    BNO055::Output output = imu_->sample();
+    if (contains_nan(output.quat) || output.quat.isApprox(Eigen::Quaternionf(0, 0, 0, 0), 1e-6)) {
+      RCLCPP_WARN(rclcpp::get_logger("ControlBoardHardwareInterface"),
+                  "%sBad IMU sample [%f, %f, %f, %f]. Retrying...%s", YELLOW_ANSI, output.quat.x(),
+                  output.quat.y(), output.quat.z(), output.quat.w(), RESET_ANSI);
+    } else {
+      auto end = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+      return std::make_pair(output, duration.count());
+    }
+    if (delay_ms > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+  }
+  return std::nullopt;
+}
+
+void IMUManager::poll_imu() {
+  auto maybe_output = sample_imu_multiple_attempts(/*max_samples=*/5, /*delay_ms=*/1);
+  if (maybe_output) {
+    // lock and copy imu data
+    std::lock_guard<std::mutex> lock(imu_mutex_);
+    imu_data = maybe_output->first;
+    imu_sampling_time_us = maybe_output->second;
+  }
+}
+
+void IMUManager::imu_read_thread_fn() {
+  while (!stop_imu_read_thread_) {
+    poll_imu();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+void IMUManager::begin(uint32_t micros_between_reports) {
+  imu_ = std::make_unique<BNO055>(IMU_I2C_DEVICE_NUMBER, micros_between_reports);
+
+  stop_imu_read_thread_ = false;
+  imu_read_thread_ = std::make_unique<std::thread>(&IMUManager::imu_read_thread_fn, this);
+}
+
+void IMUManager::stop() {
+  stop_imu_read_thread_ = true;
+  if (imu_read_thread_ && imu_read_thread_->joinable()) {
+    imu_read_thread_->join();
+  }
+}


### PR DESCRIPTION
Reading the IMU takes a long time (several milliseconds) so this PR puts reading the IMU in a separate thread so the main control board interface code is not blocked.

IMPORTANT: You must change the the i2c setup command in your /boot/firmware/config.txt to this `dtparam=i2c_arm=on,i2c_arm_baudrate=100000`. Originally it was `dtparam=i2c_arm=on,i2c_arm_baudrate=400000`